### PR TITLE
Allow the Furuta pendulum example to work on Linux

### DIFF
--- a/C/src/FurutaPendulum/FurutaPendulum.lf
+++ b/C/src/FurutaPendulum/FurutaPendulum.lf
@@ -10,7 +10,9 @@
  * This program specifies a build script that only code generates
  * and compiles the program, as usual, but also executes the
  * program and processes its output to generate and open a
- * plot.
+ * plot. You may need to change the last argument passed to 
+ * the build script to the name of a PDF viewer installed on
+ * your system.
  * 
  * You have to have installed gnuplot and have it in your
  * PATH for this script to work as expected (and also cmake).

--- a/C/src/FurutaPendulum/FurutaPendulum.lf
+++ b/C/src/FurutaPendulum/FurutaPendulum.lf
@@ -20,7 +20,8 @@
 target C {
     timeout: 3 secs,
     fast: true,
-    build: "./build_run_plot.sh FurutaPendulum pendulum"
+    flags: "-lm",
+    build: "./build_run_plot.sh FurutaPendulum pendulum open"
 }
 import PendulumController from "PendulumController.lf";
 import PendulumSimulation from "PendulumSimulation.lf";

--- a/C/src/FurutaPendulum/build_run_plot.sh
+++ b/C/src/FurutaPendulum/build_run_plot.sh
@@ -2,7 +2,8 @@
 # This script compiles the generated code,
 # executes it, and plots the results.
 # The first argument is the name of the main reactor,
-# and the second is the root name of the gnuplot file to use.
+# the second is the root name of the gnuplot file to use,
+# and the last argument is the viewer to render the PDF in.
 
 # Build the generated code.
 cd ${LF_SOURCE_GEN_DIRECTORY}
@@ -15,6 +16,14 @@ mv $1 ${LF_BIN_DIRECTORY}
 # Invoke the executable.
 ${LF_BIN_DIRECTORY}/$1
 
-# Plot the results, which have appeared in the src-gen directory.
+# Plot the results, which have appeared in the src directory.
 gnuplot ${LF_SOURCE_DIRECTORY}/$2.gnuplot
-open $2.pdf
+
+# Open the produced PDF using the specified viewer
+if ! command -v $3 &> /dev/null
+then
+    echo "'$3' could not be found; please specify another PDF viewer."
+    exit
+else
+    $3 $2.pdf &
+fi


### PR DESCRIPTION
Summary:
- on Linux, the `-lm` flag is required, so this flag was added
- Linux does not have a generic `open` command, so I made the viewer a parameter of the build script